### PR TITLE
削除フラグを見て生徒一覧で非表示にする処理を追加

### DIFF
--- a/src/main/java/raisetech/student/management/controller/converter/StudentConverter.java
+++ b/src/main/java/raisetech/student/management/controller/converter/StudentConverter.java
@@ -14,17 +14,19 @@ public class StudentConverter {
       List<StudentsCourses> studentsCourses) {
     List<StudentDetail> studentDetails = new ArrayList<>();
     for (Student student : students) {
-      StudentDetail studentDetail = new StudentDetail();
-      studentDetail.setStudent(student);
+      if(!student.isDeleted()) {
+        StudentDetail studentDetail = new StudentDetail();
+        studentDetail.setStudent(student);
 
-      List<StudentsCourses> convertStudentCourses = new ArrayList<>();
-      for (StudentsCourses StudentCourse : studentsCourses) {
-        if (student.getId() == StudentCourse.getStudentId()) {
-          convertStudentCourses.add(StudentCourse);
+        List<StudentsCourses> convertStudentCourses = new ArrayList<>();
+        for (StudentsCourses StudentCourse : studentsCourses) {
+          if (student.getId() == StudentCourse.getStudentId()) {
+            convertStudentCourses.add(StudentCourse);
+          }
         }
-      }
         studentDetail.setStudentsCourses(convertStudentCourses);
-      studentDetails.add(studentDetail);
+        studentDetails.add(studentDetail);
+      }
     }
     return studentDetails;
   }

--- a/src/main/java/raisetech/student/management/data/Student.java
+++ b/src/main/java/raisetech/student/management/data/Student.java
@@ -17,6 +17,6 @@ public class Student {
   private int age;
   private String gender;
   private String remark;
-  private boolean isDeleted;
+  private boolean deleted;
 
 }

--- a/src/main/java/raisetech/student/management/repository/StudentRepository.java
+++ b/src/main/java/raisetech/student/management/repository/StudentRepository.java
@@ -54,17 +54,8 @@ public interface StudentRepository {
 
   /**
    * 新規受講生の情報を登録します。
-   *
-   * @param newStudentId：新規受講生のID
-   * @param newStudentName：新規受講生の名前
-   * @param newStudentFurigana：新規受講生の名前のフリガナ
-   * @param newStudentNickName：新規受講生のニックネーム
-   * @param newStudentEmail：新規受講生のメールアドレス
-   * @param newStudentArea：新規受講生の住んでいる地域
-   * @param newStudentAge：新規受講生の年齢
-   * @param newStudentGender：新規受講生の性別
    */
-  @Insert("INSERT INTO students (id,"
+  @Insert("INSERT INTO students ("
       + " name, "
       + "furigana, "
       + "nickname, "
@@ -73,17 +64,14 @@ public interface StudentRepository {
       + "age, "
       + "gender) "
       + "VALUES "
-      + "(#{newStudentId}, "
-      + "#{newStudentName}, "
-      + "#{newStudentFurigana}, "
-      + "#{newStudentNickName}, "
-      + "#{newStudentEmail}, "
-      + "#{newStudentArea}, "
-      + "#{newStudentAge}, "
-      + "#{newStudentGender})")
-  void registerNewStudent(int newStudentId, String newStudentName, String newStudentFurigana,
-      String newStudentNickName, String newStudentEmail, String newStudentArea, int newStudentAge,
-      String newStudentGender);
+      + "(#{name}, "
+      + "#{furigana}, "
+      + "#{nickname}, "
+      + "#{email}, "
+      + "#{area}, "
+      + "#{age}, "
+      + "#{gender})")
+  void registerNewStudent(Student newStudent);
 
   @Insert("INSERT INTO students_courses (course_id,"
       + "student_id, "
@@ -103,25 +91,20 @@ public interface StudentRepository {
   @Select("SELECT * FROM students_courses WHERE course_id = #{searchId}")
   StudentsCourses searchCourse(int searchId);
 
-  @Update("UPDATE students SET name = #{updateStudentName},"
-      + " furigana = #{updateStudentFurigana},"
-      + " nickname = #{updateStudentNickName},"
-      + " email = #{updateStudentEmail},"
-      + " area = #{updateStudentArea},"
-      + " age = #{updateStudentAge},"
-      + " gender = #{updateStudentGender},"
-      + " remark = #{updateStudentRemark},"
+  @Update("UPDATE students SET name = #{name},"
+      + " furigana = #{furigana},"
+      + " nickname = #{nickname},"
+      + " email = #{email},"
+      + " area = #{area},"
+      + " age = #{age},"
+      + " gender = #{gender},"
+      + " remark = #{remark},"
       + " deleted = #{deleted}"
-      + " WHERE id = #{searchStudentId}")
-  void updateStudentInfo(int searchStudentId, String updateStudentName,
-      String updateStudentFurigana,
-      String updateStudentNickName, String updateStudentEmail, String updateStudentArea,
-      int updateStudentAge,
-      String updateStudentGender, String updateStudentRemark, boolean deleted);
+      + " WHERE id = #{id}")
+  void updateStudentInfo(Student updateStudent);
 
-  @Update("UPDATE students_courses SET start_date = #{updateStartDate},"
-      + " end_date = #{updateEndDate}"
-      + " WHERE course_id = #{searchCourseId}")
-  void updateStudentCourseInfo(int searchCourseId, LocalDate updateStartDate,
-      LocalDate updateEndDate);
+  @Update("UPDATE students_courses SET start_date = #{startDate},"
+      + " end_date = #{endDate}"
+      + " WHERE course_id = #{courseId}")
+  void updateStudentCourseInfo(StudentsCourses updatedCourses);
 }

--- a/src/main/java/raisetech/student/management/repository/StudentRepository.java
+++ b/src/main/java/raisetech/student/management/repository/StudentRepository.java
@@ -40,7 +40,7 @@ public interface StudentRepository {
       @Result(property = "startDate", column = "start_date"),
       @Result(property = "endDate", column = "end_date"),
       @Result(property = "remark", column = "remark"),
-      @Result(property = "isDeleted", column = "isDeleted")
+      @Result(property = "deleted", column = "deleted")
   })
   List<StudentsCourses> searchStudentsCourses();
 
@@ -110,13 +110,14 @@ public interface StudentRepository {
       + " area = #{updateStudentArea},"
       + " age = #{updateStudentAge},"
       + " gender = #{updateStudentGender},"
-      + " remark = #{updateStudentRemark}"
+      + " remark = #{updateStudentRemark},"
+      + " deleted = #{deleted}"
       + " WHERE id = #{searchStudentId}")
   void updateStudentInfo(int searchStudentId, String updateStudentName,
       String updateStudentFurigana,
       String updateStudentNickName, String updateStudentEmail, String updateStudentArea,
       int updateStudentAge,
-      String updateStudentGender, String updateStudentRemark);
+      String updateStudentGender, String updateStudentRemark, boolean deleted);
 
   @Update("UPDATE students_courses SET start_date = #{updateStartDate},"
       + " end_date = #{updateEndDate}"

--- a/src/main/java/raisetech/student/management/service/StudentService.java
+++ b/src/main/java/raisetech/student/management/service/StudentService.java
@@ -46,9 +46,7 @@ public class StudentService {
 
   @Transactional
   public void registerStudent(Student newStudent) {
-    repository.registerNewStudent(0, newStudent.getName(), newStudent.getFurigana(),
-        newStudent.getNickname(), newStudent.getEmail(), newStudent.getArea(), newStudent.getAge(),
-        newStudent.getGender());
+    repository.registerNewStudent(newStudent);
   }
 
   @Transactional
@@ -59,15 +57,11 @@ public class StudentService {
 
   @Transactional
   public void updateStudent(Student updateStudent) {
-    repository.updateStudentInfo(updateStudent.getId(), updateStudent.getName(),
-        updateStudent.getFurigana(), updateStudent.getNickname(), updateStudent.getEmail(),
-        updateStudent.getArea(), updateStudent.getAge(), updateStudent.getGender(),
-        updateStudent.getRemark(),updateStudent.isDeleted());
+    repository.updateStudentInfo(updateStudent);
   }
 
   @Transactional
   public void updateStudentCourse(StudentsCourses updatedCourses) {
-    repository.updateStudentCourseInfo(updatedCourses.getCourseId(), updatedCourses.getStartDate(),
-        updatedCourses.getEndDate());
+    repository.updateStudentCourseInfo(updatedCourses);
   }
 }

--- a/src/main/java/raisetech/student/management/service/StudentService.java
+++ b/src/main/java/raisetech/student/management/service/StudentService.java
@@ -62,7 +62,7 @@ public class StudentService {
     repository.updateStudentInfo(updateStudent.getId(), updateStudent.getName(),
         updateStudent.getFurigana(), updateStudent.getNickname(), updateStudent.getEmail(),
         updateStudent.getArea(), updateStudent.getAge(), updateStudent.getGender(),
-        updateStudent.getRemark());
+        updateStudent.getRemark(),updateStudent.isDeleted());
   }
 
   @Transactional

--- a/src/main/resources/templates/updateStudent.html
+++ b/src/main/resources/templates/updateStudent.html
@@ -10,8 +10,7 @@
 <h2>入力フォーム</h2>
 <p th:text="${message}"></p>
 <p style="color:red" th:text="${errorMessage}"></p>
-<form th:action="@{/updateStudent/{id}(id=${studentId})}" th:object="${updatedStudent}"
-      method="post">
+<form th:action="@{/updateStudent/{id}(id=${studentId})}" th:object="${updatedStudent}" method="post">
   <input type="hidden" th:field="*{student.id}" required/>
   <div>
     <label for="name">名前:</label>
@@ -45,6 +44,10 @@
     <label for="name">備考:</label>
     <input type="text" id="remark" th:field="*{student.remark}" />
   </div>
+  <div>
+    <label><input type="checkbox" th:field="*{student.deleted}"/> 生徒情報を削除する</label>
+  </div>
+
 
   <table border="1">
     <h2>コース情報</h2>


### PR DESCRIPTION
### **概要（動作確認写真）**
①生徒情報一覧で「ID：6」を選択
<img width="618" alt="スクリーンショット 2025-03-18 235038" src="https://github.com/user-attachments/assets/7bbe5491-b671-409d-9a41-9c7c552ad683" />

②生徒情報を削除するにチェックが入っていない状態
<img width="251" alt="スクリーンショット 2025-03-18 235204" src="https://github.com/user-attachments/assets/21a6a769-56ba-434d-a2f3-33c8a84a65a0" />

③生徒情報を削除するに☑を入れて「更新」を選択
<img width="250" alt="スクリーンショット 2025-03-18 235248" src="https://github.com/user-attachments/assets/31145bf3-5c3d-4f5f-842f-c316ca0c3099" />

④生徒情報一覧で「ID：6」が消えていることを確認できる。※
<img width="617" alt="スクリーンショット 2025-03-18 235318" src="https://github.com/user-attachments/assets/d484bdac-15df-4595-af03-d33d6fe1bf28" />

※DB上にはデータが残っており、deletedが1になっている
<img width="872" alt="スクリーンショット 2025-03-19 000851" src="https://github.com/user-attachments/assets/f9432437-82d0-4319-b5a0-bc2943c3f7ac" />

変更内容
●コンバーター
　・生徒削除フラグが立っていなかったら、studentDetail型にデータを格納する処理を追加
●データ
　・生徒削除フラグisDeletedをdeletedに変更
●リポジトリ
　・生徒削除フラグisDeletedをdeletedに変更
　・生徒情報のUPDATE 文にdeletedも追加
●サービス
　・UPDATE 文の引数にdeletedも追加
●テンプレート
　・生徒情報を削除するか入力するチェックボックスを追加

